### PR TITLE
Return empty string if resultrow type is not set to 'cal'

### DIFF
--- a/Resources/Private/Partials/CalDate.html
+++ b/Resources/Private/Partials/CalDate.html
@@ -71,4 +71,5 @@
             </f:format.raw>
         </f:spaceless>
     </f:then>
+    <f:else>""</f:else>
 </f:if>


### PR DESCRIPTION
This fixes a bug where an empty string would get returned when the resultrow type is not 'cal'. 
The DecodeViewHelper in the Partial "ResultRow" would then throw an error (Failure "Syntax error" occured when running json_decode() for string: ).